### PR TITLE
Modernize package

### DIFF
--- a/Sources/SwiftKeychain/Keychain.swift
+++ b/Sources/SwiftKeychain/Keychain.swift
@@ -46,7 +46,7 @@ extension KeychainItemType {
     internal var attributesToSave: [String: Any] {
         
         var itemAttributes = attributes
-        let archivedData = NSKeyedArchiver.archivedData(withRootObject: dataToStore)
+        let archivedData = try? NSKeyedArchiver.archivedData(withRootObject: dataToStore, requiringSecureCoding: false)
         
         itemAttributes[String(kSecValueData)] = archivedData
         
@@ -62,7 +62,7 @@ extension KeychainItemType {
         
         guard let valueData = attributes[String(kSecValueData)] as? Data else { return nil }
         
-        return NSKeyedUnarchiver.unarchiveObject(with: valueData) as? [String: Any] ?? nil
+        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: NSDictionary.self, from: valueData) as? [String : Any]
     }
     
     internal var attributesForFetch: [String: Any] {

--- a/Tests/SwiftKeychainTests/GenericPasswordTypeExtensionsTests.swift
+++ b/Tests/SwiftKeychainTests/GenericPasswordTypeExtensionsTests.swift
@@ -12,9 +12,9 @@ import XCTest
 struct MockGenericPasswordItem: KeychainGenericPasswordType {
     
     let accountName: String
-    var data = [String: Any]()
+    var data = KeychainData()
     
-    var dataToStore: [String: Any] {
+    var dataToStore: KeychainData {
         
         return ["token": "123456"]
     }

--- a/Tests/SwiftKeychainTests/KeychainItemTypeExtensionsTests.swift
+++ b/Tests/SwiftKeychainTests/KeychainItemTypeExtensionsTests.swift
@@ -44,7 +44,7 @@ class MockKeychain: KeychainServiceType {
         
         isFetchCalled = true
         
-        let data = NSKeyedArchiver.archivedData(withRootObject: ["token": "123456"])
+        let data = try NSKeyedArchiver.archivedData(withRootObject: ["token": "123456"], requiringSecureCoding: false)
         
         return [String(kSecValueData): data]
     }
@@ -59,12 +59,12 @@ class KeychainItemTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(item.accessMode, String(kSecAttrAccessibleWhenUnlocked), "Should return the default access mode")
     }
     
-    func testAttributesToSave() {
+    func testAttributesToSave() throws {
         
         let item = MockKeychainItem()
         
         let expectedSecClass = String(kSecClassGenericPassword)
-        let expectedData = NSKeyedArchiver.archivedData(withRootObject: ["token": "123456"])
+        let expectedData = try NSKeyedArchiver.archivedData(withRootObject: ["token": "123456"], requiringSecureCoding: false)
         
         let attriburesToSave = item.attributesToSave
         
@@ -122,32 +122,32 @@ class KeychainItemTypeExtensionsTests: XCTestCase {
         XCTAssertEqual(secReturnAttributes, true, "Should contain true in kSecReturnAttributes")
     }
     
-    func testSaveInKeychain() {
+    func testSaveInKeychain() throws {
         
         let keychain = MockKeychain()
         let item = MockKeychainItem()
         
-        try! item.saveInKeychain(keychain)
+        try item.saveInKeychain(keychain)
         
         XCTAssertEqual(keychain.isInsertCalled, true, "Should call the Keychain to insert the item")
     }
     
-    func testRemoveFromKeychain() {
+    func testRemoveFromKeychain() throws {
         
         let keychain = MockKeychain()
         let item = MockKeychainItem()
         
-        try! item.removeFromKeychain(keychain)
+        try item.removeFromKeychain(keychain)
         
         XCTAssertEqual(keychain.isRemoveCalled, true, "Should call the keychain to remove the item")
     }
     
-    func testFetchFromKeychain() {
+    func testFetchFromKeychain() throws {
         
         let keychain = MockKeychain()
         var item = MockKeychainItem()
         
-        let result = try! item.fetchFromKeychain(keychain)
+        let result = try item.fetchFromKeychain(keychain)
         
         let token = result.data["token"] as? String ?? ""
         

--- a/Tests/SwiftKeychainTests/KeychainItemTypeExtensionsTests.swift
+++ b/Tests/SwiftKeychainTests/KeychainItemTypeExtensionsTests.swift
@@ -11,14 +11,14 @@ import XCTest
 
 struct MockKeychainItem: KeychainItemType {
     
-    var attributes: [String: Any] {
+    var attributes: KeychainAttributes {
         
         return [String(kSecClass): kSecClassGenericPassword]
     }
     
-    var data = [String: Any]()
+    var data = KeychainData()
     
-    var dataToStore: [String: Any] {
+    var dataToStore: KeychainData {
         
         return ["token": "123456"]
     }
@@ -30,17 +30,17 @@ class MockKeychain: KeychainServiceType {
     var isRemoveCalled = false
     var isFetchCalled = false
     
-    func insertItemWithAttributes(_ attributes: [String: Any]) throws {
+    func insertItemWithAttributes(_ attributes: KeychainAttributes) throws {
         
         isInsertCalled = true
     }
     
-    func removeItemWithAttributes(_ attributes: [String: Any]) throws {
+    func removeItemWithAttributes(_ attributes: KeychainAttributes) throws {
         
         isRemoveCalled = true
     }
     
-    func fetchItemWithAttributes(_ attributes: [String: Any]) throws -> [String: Any]? {
+    func fetchItemWithAttributes(_ attributes: KeychainAttributes) throws -> KeychainItem? {
         
         isFetchCalled = true
         

--- a/Tests/SwiftKeychainTests/KeychainTests.swift
+++ b/Tests/SwiftKeychainTests/KeychainTests.swift
@@ -59,13 +59,13 @@ class KeychainTests: XCTestCase {
         XCTAssertEqual(hasError, true, "Should throw error when the operation fails")
     }
     
-    func testRemoveItemWithAttributes() {
+    func testRemoveItemWithAttributes() throws {
         
         let item = MockGenericPasswordItem(accountName: "John_testRemoveItemWithAttributes")
         let keychain = Keychain()
         var hasError = false
         
-        try! keychain.insertItemWithAttributes(item.attributes)
+        try keychain.insertItemWithAttributes(item.attributes)
         
         do {
         
@@ -97,14 +97,14 @@ class KeychainTests: XCTestCase {
         XCTAssertEqual(hasError, true, "Should throw error when the operation fails")
     }
     
-    func testFetchItemWithAttributes() {
+    func testFetchItemWithAttributes() throws {
         
         let item = MockGenericPasswordItem(accountName: "John_testFetchItemWithAttributes")
         let keychain = Keychain()
         var hasError = false
         var fetchedToken = ""
         
-        try! keychain.insertItemWithAttributes(item.attributesToSave)
+        try keychain.insertItemWithAttributes(item.attributesToSave)
         
         do {
             
@@ -143,14 +143,14 @@ class KeychainTests: XCTestCase {
         XCTAssertEqual(hasError, true, "Should throw error when the operation fails")
     }
     
-    func testFetchItemWithAttributesReturnsNilIfResultIsNotADictionary() {
+    func testFetchItemWithAttributesReturnsNilIfResultIsNotADictionary() throws {
         
         let item = MockGenericPasswordItem(accountName: "John_testFetchItemWithAttributesReturnsNilIfResultIsNotADictionary")
         let keychain = Keychain()
         
-        try! keychain.insertItemWithAttributes(item.attributes)
+        try keychain.insertItemWithAttributes(item.attributes)
         
-        let result = try! keychain.fetchItemWithAttributes(item.attributes)
+        let result = try keychain.fetchItemWithAttributes(item.attributes)
         
         XCTAssertNil(result, "Should return nil if the result is not a dictionary")
     }


### PR DESCRIPTION
https://sli-do.atlassian.net/browse/PS-22608

- Make KeychainTests throwing and avoid using try!
- Replace deprecated archiver/unarchiver calls with modern ones to avoid warnings
- Make keychain items, attributes, and data conform to Sendable (Swift 6 concurrency)