### PR TITLE
Bring back support for classes

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ You create an implementation of the `KeychainGenericPasswordType` protocol that 
 
 Then you call the `KeychainItemType` methods to save, remove or fetch the item from the provided as argument `KeychainServiceType` protocol implementation.
 
-![SwiftKeychain Protocols](https://github.com/slidoapp/SwiftKeychain/blob/master/Resources/Protocols.png?raw=true)
+![SwiftKeychain Protocols](Resources/Protocols.png)
 
 Let's say we want to store the access token and username for an Instagram account in the Keychain:
 
@@ -16,9 +16,9 @@ Let's say we want to store the access token and username for an Instagram accoun
 struct InstagramAccount: KeychainGenericPasswordType {
     let accountName: String
     let token: String
-    var data = [String: AnyObject]()
+    var data = KeychainData()
     
-    var dataToStore: [String: AnyObject] {
+    var dataToStore: KeychainData {
         return ["token": token]
     }
     
@@ -33,7 +33,7 @@ struct InstagramAccount: KeychainGenericPasswordType {
 }
 ```
 
-In `var dataToStore: [String: AnyObject]` you return the Dictionary that you want to be saved in the Keychain and when you fetch the item from the Keychain its data will be populated in your `var data: [String: AnyObject]` property.
+In `var dataToStore: KeychainData` you return the Dictionary (`KeychainData` is just an alias for `[String: any Sendable]`) that you want to be saved in the Keychain and when you fetch the item from the Keychain its data will be populated in your `var data: KeychainData` property.
 
 ### Save Item
 ```swift
@@ -73,6 +73,44 @@ do {
     print(error)
 }
 ```
+
+### Support for classes
+By default, stored data supports only value types such as strings and numbers. If you want to store objects of any class (for example, `NSDate`) in the Keychain, you need to implement the `storedClasses` property of the `KeychainItemType` protocol. In this property, you must explicitly list all the class types that will be stored:
+
+```swift
+struct InstagramAccount: KeychainGenericPasswordType {
+    let accountName: String
+    let token: String
+    let tokenDate: NSDate
+    var data = KeychainData()
+    
+    var dataToStore: KeychainData {
+        return [
+            "token": token,
+            "tokenDate": tokenDate
+        ]
+    }
+        
+    var storedClasses: [AnyClass] {
+        return [NSDate.self]
+    }
+    
+    var accessToken: String? {
+        return data["token"] as? String
+    }
+
+    var accessTokenDate: NSDate? {
+        return data["tokenDate"] as? NSDate
+    }
+    
+    init(name: String, accessToken: String, accessTokenDate: NSDate) {
+        accountName = name
+        token = accessToken
+        tokenDate = accessTokenDate
+    }
+}
+```
+
 
 ## Installation
 

--- a/Sources/SwiftKeychain/Keychain.swift
+++ b/Sources/SwiftKeychain/Keychain.swift
@@ -4,6 +4,7 @@
 //
 //  Created by Yanko Dimitrov on 2/6/16.
 //  Copyright © 2016 Yanko Dimitrov. All rights reserved.
+//  Copyright © 2025 Cisco Systems, Inc.
 //
 
 import Foundation
@@ -11,109 +12,6 @@ import Foundation
 public typealias KeychainAttributes = [String: any Sendable]
 public typealias KeychainData = [String: any Sendable]
 public typealias KeychainItem = [String: any Sendable]
-
-// MARK: - KeychainServiceType
-
-public protocol KeychainServiceType {
-    
-    func insertItemWithAttributes(_ attributes: KeychainAttributes) throws
-    func removeItemWithAttributes(_ attributes: KeychainAttributes) throws
-    func fetchItemWithAttributes(_ attributes: KeychainAttributes) throws -> KeychainItem?
-}
-
-// MARK: - KeychainItemType
-
-public protocol KeychainItemType {
-    
-    var accessMode: String { get }
-    var accessGroup: String? { get }
-    var attributes: KeychainAttributes { get }
-    var data: KeychainData { get set }
-    var dataToStore: KeychainData { get }
-}
-
-extension KeychainItemType {
-    
-    public var accessMode: String {
-        
-        return String(kSecAttrAccessibleWhenUnlocked)
-    }
-    
-    public var accessGroup: String? {
-        
-        return nil
-    }
-}
-
-extension KeychainItemType {
-    
-    internal var attributesToSave: KeychainAttributes {
-        
-        var itemAttributes = attributes
-        let archivedData = try? NSKeyedArchiver.archivedData(withRootObject: dataToStore, requiringSecureCoding: false)
-        
-        itemAttributes[String(kSecValueData)] = archivedData
-        
-        if let group = accessGroup {
-            
-            itemAttributes[String(kSecAttrAccessGroup)] = group
-        }
-        
-        return itemAttributes
-    }
-    
-    internal func dataFromAttributes(_ attributes: KeychainAttributes) -> KeychainData? {
-        
-        guard let valueData = attributes[String(kSecValueData)] as? Data else { return nil }
-        
-        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: NSDictionary.self, from: valueData) as? KeychainData
-    }
-    
-    internal var attributesForFetch: KeychainAttributes {
-        
-        var itemAttributes = attributes
-        
-        itemAttributes[String(kSecReturnData)] = kCFBooleanTrue
-        itemAttributes[String(kSecReturnAttributes)] = kCFBooleanTrue
-        
-        if let group = accessGroup {
-            
-            itemAttributes[String(kSecAttrAccessGroup)] = group
-        }
-        
-        return itemAttributes
-    }
-}
-
-// MARK: - KeychainGenericPasswordType
-
-public protocol KeychainGenericPasswordType: KeychainItemType {
-    
-    var serviceName: String { get }
-    var accountName: String { get }
-}
-
-extension KeychainGenericPasswordType {
-    
-    public var serviceName: String {
-        
-        return "swift.keychain.service"
-    }
-    
-    public var attributes: KeychainAttributes {
-    
-        var attributes = KeychainAttributes()
-        
-        attributes[String(kSecClass)] = kSecClassGenericPassword
-        attributes[String(kSecAttrAccessible)] = accessMode
-        attributes[String(kSecAttrService)] = serviceName
-        attributes[String(kSecAttrAccount)] = accountName
-        
-        return attributes
-    }
-}
-
-// MARK: - Keychain
 
 public struct Keychain: KeychainServiceType {
 
@@ -172,30 +70,3 @@ public struct Keychain: KeychainServiceType {
         return nil
     }
 }
-
-// MARK: - KeychainItemType + Keychain
-
-extension KeychainItemType {
-    
-    public func saveInKeychain(_ keychain: KeychainServiceType = Keychain()) throws {
-        
-        try keychain.insertItemWithAttributes(attributesToSave)
-    }
-    
-    public func removeFromKeychain(_ keychain: KeychainServiceType = Keychain()) throws {
-        
-        try keychain.removeItemWithAttributes(attributes)
-    }
-    
-    public mutating func fetchFromKeychain(_ keychain: KeychainServiceType = Keychain()) throws -> Self {
-        
-        if  let result = try keychain.fetchItemWithAttributes(attributesForFetch),
-            let itemData = dataFromAttributes(result) {
-            
-            data = itemData
-        }
-        
-        return self
-    }
-}
-

--- a/Sources/SwiftKeychain/KeychainGenericPasswordType.swift
+++ b/Sources/SwiftKeychain/KeychainGenericPasswordType.swift
@@ -1,0 +1,36 @@
+//
+//  KeychainItemType.swift
+//  SwiftKeychain
+//
+//  Created by Dominik Paľo on 07/05/2025.
+//  Copyright © 2016 Yanko Dimitrov. All rights reserved.
+//  Copyright © 2025 Cisco Systems, Inc.
+//
+
+import Foundation
+
+public protocol KeychainGenericPasswordType: KeychainItemType {
+    
+    var serviceName: String { get }
+    var accountName: String { get }
+}
+
+extension KeychainGenericPasswordType {
+    
+    public var serviceName: String {
+        
+        return "swift.keychain.service"
+    }
+    
+    public var attributes: KeychainAttributes {
+    
+        var attributes = KeychainAttributes()
+        
+        attributes[String(kSecClass)] = kSecClassGenericPassword
+        attributes[String(kSecAttrAccessible)] = accessMode
+        attributes[String(kSecAttrService)] = serviceName
+        attributes[String(kSecAttrAccount)] = accountName
+        
+        return attributes
+    }
+}

--- a/Sources/SwiftKeychain/KeychainItemType.swift
+++ b/Sources/SwiftKeychain/KeychainItemType.swift
@@ -1,0 +1,98 @@
+//
+//  KeychainItemType.swift
+//  SwiftKeychain
+//
+//  Created by Dominik Paľo on 07/05/2025.
+//  Copyright © 2016 Yanko Dimitrov. All rights reserved.
+//  Copyright © 2025 Cisco Systems, Inc.
+//
+
+import Foundation
+
+public protocol KeychainItemType {
+    
+    var accessMode: String { get }
+    var accessGroup: String? { get }
+    var attributes: KeychainAttributes { get }
+    var data: KeychainData { get set }
+    var dataToStore: KeychainData { get }
+}
+
+extension KeychainItemType {
+    
+    public var accessMode: String {
+        
+        return String(kSecAttrAccessibleWhenUnlocked)
+    }
+    
+    public var accessGroup: String? {
+        
+        return nil
+    }
+}
+
+extension KeychainItemType {
+    
+    internal var attributesToSave: KeychainAttributes {
+        
+        var itemAttributes = attributes
+        let archivedData = try? NSKeyedArchiver.archivedData(withRootObject: dataToStore, requiringSecureCoding: false)
+        
+        itemAttributes[String(kSecValueData)] = archivedData
+        
+        if let group = accessGroup {
+            
+            itemAttributes[String(kSecAttrAccessGroup)] = group
+        }
+        
+        return itemAttributes
+    }
+    
+    internal func dataFromAttributes(_ attributes: KeychainAttributes) -> KeychainData? {
+        
+        guard let valueData = attributes[String(kSecValueData)] as? Data else { return nil }
+        
+        return try? NSKeyedUnarchiver.unarchivedObject(ofClass: NSDictionary.self, from: valueData) as? KeychainData
+    }
+    
+    internal var attributesForFetch: KeychainAttributes {
+        
+        var itemAttributes = attributes
+        
+        itemAttributes[String(kSecReturnData)] = kCFBooleanTrue
+        itemAttributes[String(kSecReturnAttributes)] = kCFBooleanTrue
+        
+        if let group = accessGroup {
+            
+            itemAttributes[String(kSecAttrAccessGroup)] = group
+        }
+        
+        return itemAttributes
+    }
+}
+
+// MARK: - KeychainItemType + Keychain
+
+extension KeychainItemType {
+    
+    public func saveInKeychain(_ keychain: KeychainServiceType = Keychain()) throws {
+        
+        try keychain.insertItemWithAttributes(attributesToSave)
+    }
+    
+    public func removeFromKeychain(_ keychain: KeychainServiceType = Keychain()) throws {
+        
+        try keychain.removeItemWithAttributes(attributes)
+    }
+    
+    public mutating func fetchFromKeychain(_ keychain: KeychainServiceType = Keychain()) throws -> Self {
+        
+        if  let result = try keychain.fetchItemWithAttributes(attributesForFetch),
+            let itemData = dataFromAttributes(result) {
+            
+            data = itemData
+        }
+        
+        return self
+    }
+}

--- a/Sources/SwiftKeychain/KeychainServiceType.swift
+++ b/Sources/SwiftKeychain/KeychainServiceType.swift
@@ -1,0 +1,17 @@
+//
+//  KeychainItemType.swift
+//  SwiftKeychain
+//
+//  Created by Dominik Paľo on 07/05/2025.
+//  Copyright © 2016 Yanko Dimitrov. All rights reserved.
+//  Copyright © 2025 Cisco Systems, Inc.
+//
+
+import Foundation
+
+public protocol KeychainServiceType {
+    
+    func insertItemWithAttributes(_ attributes: KeychainAttributes) throws
+    func removeItemWithAttributes(_ attributes: KeychainAttributes) throws
+    func fetchItemWithAttributes(_ attributes: KeychainAttributes) throws -> KeychainItem?
+}

--- a/Tests/SwiftKeychainTests/GenericPasswordTypeExtensionsTests.swift
+++ b/Tests/SwiftKeychainTests/GenericPasswordTypeExtensionsTests.swift
@@ -4,30 +4,15 @@
 //
 //  Created by Yanko Dimitrov on 2/6/16.
 //  Copyright © 2016 Yanko Dimitrov. All rights reserved.
+//  Copyright © 2025 Cisco Systems, Inc.
 //
 
 import XCTest
 @testable import SwiftKeychain
 
-struct MockGenericPasswordItem: KeychainGenericPasswordType {
-    
-    let accountName: String
-    var data = KeychainData()
-    
-    var dataToStore: KeychainData {
-        
-        return ["token": "123456"]
-    }
-    
-    init(accountName: String) {
-        
-        self.accountName = accountName
-    }
-}
-
 class GenericPasswordTypeExtensionsTests: XCTestCase {
     
-    func testDefaultSerciceName() {
+    func testDefaultServiceName() {
         
         let item = MockGenericPasswordItem(accountName: "John")
         let expectedServiceName = "swift.keychain.service"

--- a/Tests/SwiftKeychainTests/MockKeychain.swift
+++ b/Tests/SwiftKeychainTests/MockKeychain.swift
@@ -1,0 +1,40 @@
+//
+//  MockKeychain.swift
+//  SwiftKeychain
+//
+//  Created by Dominik Paľo on 07/05/2025.
+//  Copyright © 2016 Yanko Dimitrov. All rights reserved.
+//  Copyright © 2025 Cisco Systems, Inc.
+//
+
+import XCTest
+import SwiftKeychain
+
+class MockKeychain: KeychainServiceType {
+    
+    var isInsertCalled = false
+    var isRemoveCalled = false
+    var isFetchCalled = false
+    
+    func insertItemWithAttributes(_ attributes: KeychainAttributes) throws {
+        
+        isInsertCalled = true
+    }
+    
+    func removeItemWithAttributes(_ attributes: KeychainAttributes) throws {
+        
+        isRemoveCalled = true
+    }
+    
+    func fetchItemWithAttributes(_ attributes: KeychainAttributes) throws -> KeychainItem? {
+        
+        isFetchCalled = true
+        
+        let data = try NSKeyedArchiver.archivedData(withRootObject: [
+            "token": "123456",
+            "date": NSDate.init(timeIntervalSince1970: 123456)
+        ], requiringSecureCoding: true)
+        
+        return [String(kSecValueData): data]
+    }
+}

--- a/Tests/SwiftKeychainTests/MockKeychainItems.swift
+++ b/Tests/SwiftKeychainTests/MockKeychainItems.swift
@@ -1,0 +1,104 @@
+//
+//  MockKeychainItem.swift
+//  SwiftKeychain
+//
+//  Created by Dominik Paľo on 07/05/2025.
+//  Copyright © 2016 Yanko Dimitrov. All rights reserved.
+//  Copyright © 2025 Cisco Systems, Inc.
+//
+
+import XCTest
+import SwiftKeychain
+
+/// A mock implementation of `KeychainItemType` containing `NSDate` class for testing purposes.
+/// The `storedClasses` property is set to `[NSDate.self]` to allow storing the `NSDate` in the keychain.
+struct MockKeychainItem: KeychainItemType {
+    
+    var attributes: KeychainAttributes {
+        
+        return [String(kSecClass): kSecClassGenericPassword]
+    }
+    
+    var data = KeychainData()
+    
+    var dataToStore: KeychainData {
+        
+        return [
+            "token": "123456",
+            "date": NSDate(timeIntervalSince1970: 123456)
+        ]
+    }
+    
+    var storedClasses: [AnyClass] {
+
+        return [NSDate.self]
+    }
+}
+
+/// A simple mock implementation of `KeychainItemType` for testing purposes.
+/// Simple means, that it stores only value data and does not contain any classes,
+/// so the `storedClasses` property doesn't need to be set.
+struct MockKeychainItemSimple: KeychainItemType {
+    
+    var attributes: KeychainAttributes {
+        
+        return [String(kSecClass): kSecClassGenericPassword]
+    }
+    
+    var data = KeychainData()
+    
+    var dataToStore: KeychainData {
+        
+        return [
+            "token": "123456"
+        ]
+    }
+}
+
+/// A mock implementation of `KeychainGenericPasswordType` for testing purposes.
+/// The `storedClasses` property is set to `[NSDate.self]` to allow storing the `NSDate` in the keychain.
+struct MockGenericPasswordItem: KeychainGenericPasswordType {
+    
+    let accountName: String
+    var data = KeychainData()
+    
+    var dataToStore: KeychainData {
+        
+        return [
+            "token": "123456",
+            "date": NSDate(timeIntervalSince1970: 123456)
+        ]
+    }
+    
+    var storedClasses: [AnyClass] {
+
+        return [NSDate.self]
+    }
+    
+    init(accountName: String) {
+        
+        self.accountName = accountName
+    }
+}
+
+/// Thiis item is used to test the case when the `KeychainItemType` protocol is not implemented correctly.
+/// It does not implement the `storedClasses` property, which is required when the stored data contains any
+/// classes, like `NSDate` in this case.
+struct MockGenericPasswordItemMisconfigured: KeychainGenericPasswordType {
+    
+    let accountName: String
+    var data = KeychainData()
+    
+    var dataToStore: KeychainData {
+        
+        return [
+            "token": "123456",
+            "date": NSDate(timeIntervalSince1970: 123456)
+        ]
+    }
+    
+    init(accountName: String) {
+        
+        self.accountName = accountName
+    }
+}


### PR DESCRIPTION
After migrating from the deprecated [NSKeyedUnarchiver.unarchiveObject(with:)](https://developer.apple.com/documentation/foundation/nskeyedunarchiver/unarchiveobject(with:)) function
to modern [NSKeyedUnarchiver.unarchivedObject(ofClass:from:)](https://developer.apple.com/documentation/foundation/nskeyedunarchiver/unarchivedobject(ofclass:from:)),
we bumped into an issue, where classes like [NSDate](https://developer.apple.com/documentation/foundation/nsdate) are not deserialized from Keychain.

The new `unarchivedObject(ofClass:from:)` function  (secure unarchiving) now requires explicit allow-listing of all classes in the object graph.
This is a security measure to prevent arbitrary class instantiation during decoding.

Therefore, we need add an option to configure set of supported classes.


https://sli-do.atlassian.net/browse/PS-22663